### PR TITLE
Add three app links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,15 @@ Example-iOS-Apps is an amazing list for people who is begginer and learning ios 
 
 ## Content
 * [Calculator-iOS](https://github.com/imjog/Calculator-iOS) - Basic calculator app for iOS devices using Swift3. Created for learning purpose.
-* [AppleWatchCalculator](https://github.com/BalestraPatrick/AppleWatchCalculator) - A calculator for your Apple Watch but only if you have fingers small enough to press the buttons.
 * [Stopwatch](https://github.com/imjog/stopwatch) - Basic Stop Watch & Countdown app for iOS devices. Created for learning purpose.
 * [To Do List](https://github.com/imjog/todolist-ios-app) - Basic To Do List App for iOS devices using swift and xcode.
 * [Gravity Blocks](https://github.com/imjog/gravityBlocks) - A basic iOS app on basic physics concept gravity and elasticity.
 * [QR Blank](https://github.com/kahopoon/QR-Blank) - A basic QR code scanning app that checks URLs safety before advancing.
+* [AppleWatchCalculator](https://github.com/BalestraPatrick/AppleWatchCalculator) - A calculator for your Apple Watch but only if you have fingers small enough to press the buttons.
 * [done-swift](https://github.com/FancyPixel/done-swift) - Sample app to demonstrate data sharing between a WatchKit app and its main app using Realm
-* [Californication](https://github.com/vanyaland/Californication) - California points of interest
-* [how-much](https://github.com/dkhamsing/how-much) - Simple app to record how much things cost
+* [how-much](https://github.com/dkhamsing/how-much) - A simple iOS app to record how much things cost using various data persistence implementations.
+
+
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@ Example-iOS-Apps is an amazing list for people who is begginer and learning ios 
 
 ## Content
 * [Calculator-iOS](https://github.com/imjog/Calculator-iOS) - Basic calculator app for iOS devices using Swift3. Created for learning purpose.
+* [AppleWatchCalculator](https://github.com/BalestraPatrick/AppleWatchCalculator) - A calculator for your Apple Watch but only if you have fingers small enough to press the buttons.
 * [Stopwatch](https://github.com/imjog/stopwatch) - Basic Stop Watch & Countdown app for iOS devices. Created for learning purpose.
 * [To Do List](https://github.com/imjog/todolist-ios-app) - Basic To Do List App for iOS devices using swift and xcode.
 * [Gravity Blocks](https://github.com/imjog/gravityBlocks) - A basic iOS app on basic physics concept gravity and elasticity.
 * [QR Blank](https://github.com/kahopoon/QR-Blank) - A basic QR code scanning app that checks URLs safety before advancing.
+* [done-swift](https://github.com/FancyPixel/done-swift) - Sample app to demonstrate data sharing between a WatchKit app and its main app using Realm
+* [Californication](https://github.com/vanyaland/Californication) - California points of interest
+* [how-much](https://github.com/dkhamsing/how-much) - Simple app to record how much things cost
 
 ## Author
 


### PR DESCRIPTION
Added three sample apps (two for Apple Watch and the other one shows how to implement several kinds of persistence approaches).

I added three of them because the list is so small for the time being. Do you prefer that I make a PR for each addition?

## Project URL
https://github.com/BalestraPatrick/AppleWatchCalculator
https://github.com/FancyPixel/done-swift
https://github.com/dkhamsing/how-much

## Description
Added three distinct sample apps that demonstrate:

- how beginners can develop Apple Watch apps
- how to interact with Firebase
- how to use Realm (the database) to store data
- how to use User Defaults to store data
 
## Why it should be included to `example-ios-apps` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [  ] Only one project/change is in this pull request
- [ x ] Addition in chronological order (bottom of category)
- [ x ] Supports iOS 9 / tvOS 10 or later
- [ x ] Supports Swift 3 or later
- [ x ] Has a commit from less than 2 years ago
- [ x ] Has a **clear** README in English
