### PR TITLE
Added crime mapper link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Example-iOS-Apps is an amazing list for people who is begginer and learning ios 
 * [Chats](https://github.com/acani/Chats) - Open source messaging app
 * [technex-ios](https://github.com/imjog/technex-ios) - iOS app for Technex, IIT(BHU) Varanasi. This project is closed before completion. You can use this app for learning purpose.
 * [GitHawk](https://github.com/rnystrom/GitHawk) - A GitHub project manager app for iOS
+* [crime mapper] (https://github.com/swwol/CrimeMapper) - A data visualisation tool that adds publicly available crime data from UK police forces to an interactive map
 
 ## Author
 
@@ -42,7 +43,7 @@ Jogendra Singh, jogendra.singh.jog@gmail.com
 - If you have any issue or want **help**, please drop me a mail on jogendra.singh.jog@gmail.com
 ### Contributors
 Please add your name to contributors list after making atleast one contribution to this repo. Add your name in same line as you are seeing the pattern.
-1. [Jogendra Singh](https://github.com/imjog) 2. [NSMyself](https://github.com/NSMyself) 3. [hoffmanjoshua](https://github.com/hoffmanjoshua) 4. [Axieum](https://github.com/Axieum) 5. [Rizwan](https://github.com/rizwankce)
+1. [Jogendra Singh](https://github.com/imjog) 2. [NSMyself](https://github.com/NSMyself) 3. [hoffmanjoshua](https://github.com/hoffmanjoshua) 4. [Axieum](https://github.com/Axieum) 5. [Rizwan](https://github.com/rizwankce) 6.[Melissa] (https://github.com/melissa3000)
 
 # License
  * Distributed under the MIT license. See LICENSE for more information.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/swwol/CrimeMapper

## Description
A data visualisation tool that adds publicly available crime data from UK police forces to an interactive map.
 
## Why it should be included to `example-ios-apps` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] Only one project/change is in this pull request
- [x ] Addition in chronological order (bottom of category)
- [x ] Supports iOS 9 / tvOS 10 or later
- [x ] Supports Swift 3 or later
- [x ] Has a commit from less than 2 years ago
- [x ] Has a **clear** README in English
