### PR TITLE
Add ARHeadsetKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Example-iOS-Apps is an amazing list for people who are beginners and learning iO
 - Simply press <kbd>command</kbd> + <kbd>F</kbd> to search for a keyword
 - Go through our *Content Menu*
 
+## Frameworks
+* [ARHeadsetKit](https://github.com/philipturner/ARHeadsetKit) - High-level framework for experimenting with AR and using $5 Google Cardboard to replicate Hololens.
+
 ## iOS Apps that Take Part in Google Summer of Code
 * [Rocket.Chat.iOS](https://github.com/imjog/Rocket.Chat.iOS) - Rocket.Chat Native iOS Application.
 * [SUSI iOS](https://github.com/fossasia/susi_iOS) - SUSI AI iOS app by FOSSASIA.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
<!--- The project URL -->
[https://github.com/philipturner/ARHeadsetKit](https://github.com/philipturner/ARHeadsetKit)

## Description
<!--- Describe your changes in detail -->
Added a high-level framework for beginners to start working with AR without messing with ARKit. It also doubles as the world's first truly affordable AR headset experience, with Google Cardboard costing as little as $5 if you want to activate headset mode. However, there is a dire lack of apps built with ARHeadsetKit.
 
## Why it should be included to `example-ios-apps` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
